### PR TITLE
Use https instead of ssh for angular-gettext-tools dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "gettext"
   ],
   "dependencies": {
-    "angular-gettext-tools": "git@github.com:bartbutler/angular-gettext-tools.git"
+    "angular-gettext-tools": "https://github.com/bartbutler/angular-gettext-tools.git"
   }
 }


### PR DESCRIPTION
See https://github.com/ProtonMail/WebClient/issues/1
